### PR TITLE
Miscellaneous improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 web
 vendor
 node_modules
+/*.patch
 *.sql
 *.sql.gz
 *.gz

--- a/.lando.yml
+++ b/.lando.yml
@@ -38,6 +38,11 @@ tooling:
     description: Creat a patch from your committed changes on your branch.
     cmd:
       - appserver: php /app/scripts/patch-helpers.php --create-patch
+  phpunit:
+    service: appserver
+    user: www-data
+    cmd:
+      - appserver: /app/web/vendor/bin/phpunit -c /app/config
 
   test:
       service: appserver

--- a/.lando.yml
+++ b/.lando.yml
@@ -17,9 +17,7 @@ tooling:
     service: appserver
     description: Install Drupal
     cmd:
-      - drush --root=/app/web si --db-url=mysql://drupal8:drupal8@database/drupal8 -y
-      - chmod -R 777 /app/web/sites/default
-      - drush --root=/app/web --uri=https://drupal-contributions.lndo.site uli
+      - appserver: /app/scripts/site-install.sh
   patch:
     service: appserver
     description: Get a patch from a Drupal project issue queue

--- a/.lando.yml
+++ b/.lando.yml
@@ -51,11 +51,4 @@ events:
     - rm -rfv web
     - appserver: php /app/scripts/get-drupal.php
   post-rebuild:
-    - appserver: drush --root=/app/web si --db-url=mysql://drupal8:drupal8@database/drupal8 -y
-    - appserver: drush --root=/app/web en simpletest -y
-    - appserver: chmod -R 777 /app/web/sites/default
-    - appserver: drush --root=/app/web --uri=https://drupal-contributions.lndo.site uli
-    - appserver: echo "vendor" >> /app/web/.gitignore
-    - appserver: echo ".gitignore\nsites/simpletest" >> /app/web/.gitignore
-    - appserver: echo "sites/default/files" >> /app/web/.gitignore
-    - appserver: echo "sites/default/settings.php" >> /app/web/.gitignore
+    - appserver: /app/scripts/rebuild.sh

--- a/config/drupal-branch.php
+++ b/config/drupal-branch.php
@@ -4,4 +4,4 @@
  * @file
  * The branch of Drupal core targeted by the current issue.
  */
-$drupalBranch = '8.8.x';
+$drupalBranch = '8.9.x';

--- a/config/drupal-branch.php
+++ b/config/drupal-branch.php
@@ -1,0 +1,7 @@
+<?php
+
+/**
+ * @file
+ * The branch of Drupal core targeted by the current issue.
+ */
+$drupalBranch = '8.8.x';

--- a/config/phpunit.xml
+++ b/config/phpunit.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- TODO set checkForUnintentionallyCoveredCode="true" once https://www.drupal.org/node/2626832 is resolved. -->
+<!-- PHPUnit expects functional tests to be run with either a privileged user
+ or your current system user. See core/tests/README.md and
+ https://www.drupal.org/node/2116263 for details.
+-->
+<phpunit bootstrap="/app/web/core/tests/bootstrap.php" colors="true"
+         beStrictAboutTestsThatDoNotTestAnything="true"
+         beStrictAboutOutputDuringTests="true"
+         beStrictAboutChangesToGlobalState="true"
+         printerClass="\Drupal\Tests\Listeners\HtmlOutputPrinter">
+  <php>
+    <!-- Set error reporting to E_ALL. -->
+    <ini name="error_reporting" value="32767"/>
+    <!-- Do not limit the amount of memory tests take to run. -->
+    <ini name="memory_limit" value="-1"/>
+    <!-- Example SIMPLETEST_BASE_URL value: http://localhost -->
+    <env name="SIMPLETEST_BASE_URL" value="https://drupal-contributions.lndo.site/"/>
+    <!-- Example SIMPLETEST_DB value: mysql://username:password@localhost/databasename#table_prefix -->
+    <env name="SIMPLETEST_DB" value="mysql://drupal8:drupal8@database/drupal8"/>
+    <!-- Example BROWSERTEST_OUTPUT_DIRECTORY value: /path/to/webroot/sites/simpletest/browser_output -->
+    <env name="BROWSERTEST_OUTPUT_DIRECTORY" value="/app/web/sites/simpletest/browser_output"/>
+    <!-- To disable deprecation testing completely uncomment the next line. -->
+    <!-- <env name="SYMFONY_DEPRECATIONS_HELPER" value="disabled"/> -->
+    <!-- Example for changing the driver class for mink tests MINK_DRIVER_CLASS value: 'Drupal\FunctionalJavascriptTests\DrupalSelenium2Driver' -->
+    <!-- Example for changing the driver args to mink tests MINK_DRIVER_ARGS value: '["http://127.0.0.1:8510"]' -->
+    <!-- Example for changing the driver args to phantomjs tests MINK_DRIVER_ARGS_PHANTOMJS value: '["http://127.0.0.1:8510"]' -->
+    <!-- Example for changing the driver args to webdriver tests MINK_DRIVER_ARGS_WEBDRIVER value: '["firefox", null, "http://localhost:4444/wd/hub"]' -->
+	    <env name="MINK_DRIVER_ARGS_WEBDRIVER" value='["chrome", null, "http://chrome.drupal.internal:9515/wd/hub"]'/>
+	    <!-- <env name="MINK_DRIVER_ARGS_WEBDRIVER" value='["chrome", {"browserName":"chrome","chromeOptions":{"args":["- -disable-gpu","- -headless", "- -no-sandbox", "- -disable-dev-shm-usage"]}}, "http://chromedriver.drupal.internal:9515/wd/hub"]'/> -->
+  </php>
+  <testsuites>
+    <testsuite name="unit">
+      <file>./tests/TestSuites/UnitTestSuite.php</file>
+    </testsuite>
+    <testsuite name="kernel">
+      <file>./tests/TestSuites/KernelTestSuite.php</file>
+    </testsuite>
+    <testsuite name="functional">
+      <file>./tests/TestSuites/FunctionalTestSuite.php</file>
+    </testsuite>
+    <testsuite name="functional-javascript">
+      <file>./tests/TestSuites/FunctionalJavascriptTestSuite.php</file>
+    </testsuite>
+  </testsuites>
+  <listeners>
+    <listener class="\Drupal\Tests\Listeners\DrupalListener">
+    </listener>
+    <!-- The Symfony deprecation listener has to come after the Drupal listener -->
+    <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener">
+    </listener>
+  </listeners>
+  <!-- Filter for coverage reports. -->
+  <filter>
+    <whitelist>
+      <directory>./includes</directory>
+      <directory>./lib</directory>
+      <!-- Extensions can have their own test directories, so exclude those. -->
+      <directory>./modules</directory>
+      <exclude>
+        <directory>./modules/*/src/Tests</directory>
+        <directory>./modules/*/tests</directory>
+      </exclude>
+      <directory>../modules</directory>
+      <exclude>
+        <directory>../modules/*/src/Tests</directory>
+        <directory>../modules/*/tests</directory>
+        <directory>../modules/*/*/src/Tests</directory>
+        <directory>../modules/*/*/tests</directory>
+      </exclude>
+      <directory>../sites</directory>
+     </whitelist>
+  </filter>
+</phpunit>

--- a/scripts/get-drupal.php
+++ b/scripts/get-drupal.php
@@ -5,6 +5,8 @@
  * Get Drupal source code if we haven't already.
  */
 
+include '/app/config/drupal-branch.php';
+
 exec(
-  'git clone --branch 8.8.x https://git.drupalcode.org/project/drupal.git web'
+  "git clone --branch $drupalBranch https://git.drupalcode.org/project/drupal.git web"
 );

--- a/scripts/patch-helpers.php
+++ b/scripts/patch-helpers.php
@@ -4,6 +4,9 @@
  * @file
  * Get, apply, and revert patches.
  */
+
+include '/app/config/drupal-branch.php';
+
 switch ($argv[1]) {
   case '--revert':
     $patch = $argv[2];
@@ -64,13 +67,14 @@ function revertPatch($patchName) {
  * Create a patch from the committed changes on your local branch.
  */
 function createPatch() {
+  global $drupalBranch;
   exec("git -C /app/web symbolic-ref HEAD", $output);
   $branch = explode('/', $output[0]);
   $branch = end($branch);
   exec(
     "cd /app/web &&
     git add -A . &&
-    git diff --cached 8.8.x > /app/$branch.patch &&
+    git diff --cached $drupalBranch > /app/$branch.patch &&
     git reset HEAD"
   );
 }

--- a/scripts/patch-helpers.php
+++ b/scripts/patch-helpers.php
@@ -4,20 +4,25 @@
  * @file
  * Get, apply, and revert patches.
  */
-$url = $argv[1];
-$urlParts = explode('/', $url);
-$patchName = end($urlParts);
-if (strpos($url, 'https') !== FALSE) {
-  getPatch($url);
-  movePatch($patchName);
-  applyPatch($patchName);
-}
-elseif ($url === '--revert') {
-  $patch = $argv[2];
-  revertPatch($patch);
-}
-elseif ($url === '--create-patch') {
-  createPatch();
+switch ($argv[1]) {
+  case '--revert':
+    $patch = $argv[2];
+    revertPatch($patch);
+    break;
+
+  case '--create-patch':
+    createPatch();
+    break;
+
+  default:
+    $url = $argv[1];
+    if (strpos($url, 'https') !== FALSE) {
+      $urlParts = explode('/', $url);
+      $patchName = end($urlParts);
+      getPatch($url);
+      movePatch($patchName);
+      applyPatch($patchName);
+    }
 }
 
 /**

--- a/scripts/patch-helpers.php
+++ b/scripts/patch-helpers.php
@@ -57,8 +57,7 @@ function movePatch($patchName) {
  */
 function applyPatch($patchName) {
   exec(
-    "cd /app/web &&
-    git apply -v $patchName"
+    "git -C /app/web apply -v $patchName"
   );
 }
 
@@ -70,8 +69,7 @@ function applyPatch($patchName) {
  */
 function revertPatch($patchName) {
   exec(
-    "cd /app/web &&
-    git apply -Rv $patchName"
+    "git -C /app/web apply -Rv $patchName"
   );
 }
 
@@ -79,11 +77,10 @@ function revertPatch($patchName) {
  * Create a patch from the committed changes on your local branch.
  */
 function createPatch() {
-  exec("cd /app/web && git symbolic-ref HEAD", $output);
+  exec("git -C /app/web symbolic-ref HEAD", $output);
   $branch = explode('/', $output[0]);
   $branch = end($branch);
   exec(
-    "cd /app/web &&
-    git diff 8.8.x > $branch.patch"
+    "git -C /app/web diff 8.8.x > $branch.patch"
   );
 }

--- a/scripts/patch-helpers.php
+++ b/scripts/patch-helpers.php
@@ -4,11 +4,9 @@
  * @file
  * Get, apply, and revert patches.
  */
-//print_r($argv);exit;
 $url = $argv[1];
 $urlParts = explode('/', $url);
 $patchName = end($urlParts);
-//print_r($url);
 if (strpos($url, 'https') !== FALSE) {
   getPatch($url);
   movePatch($patchName);

--- a/scripts/patch-helpers.php
+++ b/scripts/patch-helpers.php
@@ -68,6 +68,9 @@ function createPatch() {
   $branch = explode('/', $output[0]);
   $branch = end($branch);
   exec(
-    "git -C /app/web diff 8.8.x > /app/$branch.patch"
+    "cd /app/web &&
+    git add -A . &&
+    git diff --cached 8.8.x > /app/$branch.patch &&
+    git reset HEAD"
   );
 }

--- a/scripts/patch-helpers.php
+++ b/scripts/patch-helpers.php
@@ -20,7 +20,6 @@ switch ($argv[1]) {
       $urlParts = explode('/', $url);
       $patchName = end($urlParts);
       getPatch($url);
-      movePatch($patchName);
       applyPatch($patchName);
     }
 }
@@ -33,19 +32,7 @@ switch ($argv[1]) {
  */
 function getPatch($url) {
   exec(
-    "wget $url"
-  );
-}
-
-/**
- * Move the patch into drupal root.
- *
- * @param string $patchName
- *   The name of the patch.
- */
-function movePatch($patchName) {
-  exec(
-    "mv $patchName web/"
+    "wget -P /app $url"
   );
 }
 
@@ -57,7 +44,7 @@ function movePatch($patchName) {
  */
 function applyPatch($patchName) {
   exec(
-    "git -C /app/web apply -v $patchName"
+    "git -C /app/web apply -v /app/$patchName"
   );
 }
 
@@ -69,7 +56,7 @@ function applyPatch($patchName) {
  */
 function revertPatch($patchName) {
   exec(
-    "git -C /app/web apply -Rv $patchName"
+    "git -C /app/web apply -Rv /app/$patchName"
   );
 }
 
@@ -81,6 +68,6 @@ function createPatch() {
   $branch = explode('/', $output[0]);
   $branch = end($branch);
   exec(
-    "git -C /app/web diff 8.8.x > $branch.patch"
+    "git -C /app/web diff 8.8.x > /app/$branch.patch"
   );
 }

--- a/scripts/rebuild.sh
+++ b/scripts/rebuild.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+drush --root=/app/web si --db-url=mysql://drupal8:drupal8@database/drupal8 -y
+drush --root=/app/web en simpletest -y
+chmod -R 777 /app/web/sites/default
+drush --root=/app/web --uri=https://drupal-contributions.lndo.site uli
+echo "vendor" >> /app/web/.gitignore
+echo ".gitignore\nsites/simpletest" >> /app/web/.gitignore
+echo "sites/default/files" >> /app/web/.gitignore
+echo "sites/default/settings.php" >> /app/web/.gitignore

--- a/scripts/rebuild.sh
+++ b/scripts/rebuild.sh
@@ -2,6 +2,7 @@
 
 drush --root=/app/web si --db-url=mysql://drupal8:drupal8@database/drupal8 -y
 drush --root=/app/web en simpletest -y
+mkdir -p -m 777 /app/web/sites/simpletest/browser_output
 find /app/web/sites/default -type d -exec chmod 777 '{}' \;
 drush --root=/app/web --uri=https://drupal-contributions.lndo.site uli
 echo "vendor" >> /app/web/.gitignore

--- a/scripts/rebuild.sh
+++ b/scripts/rebuild.sh
@@ -2,7 +2,7 @@
 
 drush --root=/app/web si --db-url=mysql://drupal8:drupal8@database/drupal8 -y
 drush --root=/app/web en simpletest -y
-chmod -R 777 /app/web/sites/default
+find /app/web/sites/default -type d -exec chmod 777 '{}' \;
 drush --root=/app/web --uri=https://drupal-contributions.lndo.site uli
 echo "vendor" >> /app/web/.gitignore
 echo ".gitignore\nsites/simpletest" >> /app/web/.gitignore

--- a/scripts/site-install.sh
+++ b/scripts/site-install.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+drush --root=/app/web si --db-url=mysql://drupal8:drupal8@database/drupal8 -y
+chmod -R 777 /app/web/sites/default
+drush --root=/app/web --uri=https://drupal-contributions.lndo.site uli

--- a/scripts/site-install.sh
+++ b/scripts/site-install.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-drush --root=/app/web si --db-url=mysql://drupal8:drupal8@database/drupal8 -y
+drush --root=/app/web si --db-url=mysql://drupal8:drupal8@database/drupal8 -y $1
 find /app/web/sites/default -type d -exec chmod 777 '{}' \;
 drush --root=/app/web --uri=https://drupal-contributions.lndo.site uli

--- a/scripts/site-install.sh
+++ b/scripts/site-install.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
 drush --root=/app/web si --db-url=mysql://drupal8:drupal8@database/drupal8 -y
-chmod -R 777 /app/web/sites/default
+find /app/web/sites/default -type d -exec chmod 777 '{}' \;
 drush --root=/app/web --uri=https://drupal-contributions.lndo.site uli


### PR DESCRIPTION
Please read the extended commit messages. (In the GitHub UI, expand the `...` links.)

The `simpletest` module is deprecated, removed in Drupal 9. I added a `lando phpunit` command, but I suggest removing the dependency on `simpletest`. I am not sure whether `run-tests.sh` depends on `simpletest`.

The blog post suggests creating a branch with the pattern `ISSUE####-COMMENT#.patch`. Since `lando patch --create-patch` adds `.patxh`, that should be just `ISSUE####-COMMENT#`.

Consider using [mglaman/drupalorg-cli](/mglaman/drupalorg-cli), or joining forces with it, or taking some inspiration from it.