### PR TITLE
Add a chromedriver service for functional javascript tests

### DIFF
--- a/.lando.yml
+++ b/.lando.yml
@@ -7,6 +7,17 @@ services:
   appserver:
     run:
       - cd /app/web && composer install
+    overrides:
+      environment:
+        SIMPLETEST_BASE_URL: "http://appserver"
+        SIMPLETEST_DB: "sqlite://localhost/tmp/db.sqlite"
+        MINK_DRIVER_ARGS_WEBDRIVER: '["chrome", {"browserName":"chrome","chromeOptions":{"args":["--disable-gpu","--headless", "--no-sandbox"]}}, "http://chrome:9515"]'
+  chrome:
+    type: compose
+    app_mount: false
+    services:
+      image: drupalci/webdriver-chromedriver:production
+      command: chromedriver --log-path=/tmp/chromedriver.log --verbose --whitelisted-ips=
 
 tooling:
   drush:

--- a/.lando.yml
+++ b/.lando.yml
@@ -9,7 +9,7 @@ services:
       - cd /app/web && composer install
     overrides:
       environment:
-        SIMPLETEST_BASE_URL: "http://appserver"
+        SIMPLETEST_BASE_URL: "https://drupal-contributions.lndo.site/"
         SIMPLETEST_DB: "sqlite://localhost/tmp/db.sqlite"
         MINK_DRIVER_ARGS_WEBDRIVER: '["chrome", {"browserName":"chrome","chromeOptions":{"args":["--disable-gpu","--headless", "--no-sandbox"]}}, "http://chrome:9515"]'
   chrome:

--- a/config/phpunit.xml
+++ b/config/phpunit.xml
@@ -16,19 +16,21 @@
     <!-- Do not limit the amount of memory tests take to run. -->
     <ini name="memory_limit" value="-1"/>
     <!-- Example SIMPLETEST_BASE_URL value: http://localhost -->
-    <env name="SIMPLETEST_BASE_URL" value="https://drupal-contributions.lndo.site/"/>
+    <env name="SIMPLETEST_BASE_URL" value=""/>
     <!-- Example SIMPLETEST_DB value: mysql://username:password@localhost/databasename#table_prefix -->
-    <env name="SIMPLETEST_DB" value="mysql://drupal8:drupal8@database/drupal8"/>
+    <env name="SIMPLETEST_DB" value=""/>
     <!-- Example BROWSERTEST_OUTPUT_DIRECTORY value: /path/to/webroot/sites/simpletest/browser_output -->
     <env name="BROWSERTEST_OUTPUT_DIRECTORY" value="/app/web/sites/simpletest/browser_output"/>
     <!-- To disable deprecation testing completely uncomment the next line. -->
     <!-- <env name="SYMFONY_DEPRECATIONS_HELPER" value="disabled"/> -->
     <!-- Example for changing the driver class for mink tests MINK_DRIVER_CLASS value: 'Drupal\FunctionalJavascriptTests\DrupalSelenium2Driver' -->
+    <env name="MINK_DRIVER_CLASS" value=''/>
     <!-- Example for changing the driver args to mink tests MINK_DRIVER_ARGS value: '["http://127.0.0.1:8510"]' -->
+    <env name="MINK_DRIVER_ARGS" value=''/>
     <!-- Example for changing the driver args to phantomjs tests MINK_DRIVER_ARGS_PHANTOMJS value: '["http://127.0.0.1:8510"]' -->
-    <!-- Example for changing the driver args to webdriver tests MINK_DRIVER_ARGS_WEBDRIVER value: '["firefox", null, "http://localhost:4444/wd/hub"]' -->
-	    <env name="MINK_DRIVER_ARGS_WEBDRIVER" value='["chrome", null, "http://chrome.drupal.internal:9515/wd/hub"]'/>
-	    <!-- <env name="MINK_DRIVER_ARGS_WEBDRIVER" value='["chrome", {"browserName":"chrome","chromeOptions":{"args":["- -disable-gpu","- -headless", "- -no-sandbox", "- -disable-dev-shm-usage"]}}, "http://chromedriver.drupal.internal:9515/wd/hub"]'/> -->
+    <env name="MINK_DRIVER_ARGS_PHANTOMJS" value=''/>
+    <!-- Example for changing the driver args to webdriver tests MINK_DRIVER_ARGS_WEBDRIVER value: '["chrome", { "chromeOptions": { "w3c": false } }, "http://localhost:4444/wd/hub"]' For using the Firefox browser, replace "chrome" with "firefox" -->
+    <env name="MINK_DRIVER_ARGS_WEBDRIVER" value=''/>
   </php>
   <testsuites>
     <testsuite name="unit">
@@ -42,6 +44,9 @@
     </testsuite>
     <testsuite name="functional-javascript">
       <file>./tests/TestSuites/FunctionalJavascriptTestSuite.php</file>
+    </testsuite>
+    <testsuite name="build">
+      <file>./tests/TestSuites/BuildTestSuite.php</file>
     </testsuite>
   </testsuites>
   <listeners>


### PR DESCRIPTION
Thanks to https://agile.coop/blog/how-to-run-drupal-s-php-unit-tests-in-lando/

Example: run a kernel test, a functional test, and a functional javascript test:

```
benji@pop-os:~/repos/drupal-contributions$ lando phpunit web/core/modules/help/tests/src/Kernel/HelpEmptyPageTest.php
PHPUnit 6.5.14 by Sebastian Bergmann and contributors.

Testing Drupal\Tests\help\Kernel\HelpEmptyPageTest
.                                                                   1 / 1 (100%)

Time: 1.35 seconds, Memory: 6.00MB

OK (1 test, 4 assertions)
benji@pop-os:~/repos/drupal-contributions$ lando phpunit web/core/modules/color/tests/src/Functional/ColorConfigSchemaTest.php
PHPUnit 6.5.14 by Sebastian Bergmann and contributors.

Testing Drupal\Tests\color\Functional\ColorConfigSchemaTest
.                                                                   1 / 1 (100%)

Time: 9.04 seconds, Memory: 6.00MB

OK (1 test, 8 assertions)

HTML output was generated
http://appserver/sites/simpletest/browser_output/Drupal_Tests_color_Functional_ColorConfigSchemaTest-7-19312533.html
http://appserver/sites/simpletest/browser_output/Drupal_Tests_color_Functional_ColorConfigSchemaTest-8-19312533.html
http://appserver/sites/simpletest/browser_output/Drupal_Tests_color_Functional_ColorConfigSchemaTest-9-19312533.html
http://appserver/sites/simpletest/browser_output/Drupal_Tests_color_Functional_ColorConfigSchemaTest-10-19312533.html
http://appserver/sites/simpletest/browser_output/Drupal_Tests_color_Functional_ColorConfigSchemaTest-11-19312533.html
http://appserver/sites/simpletest/browser_output/Drupal_Tests_color_Functional_ColorConfigSchemaTest-12-19312533.html
benji@pop-os:~/repos/drupal-contributions$ lando phpunit web/core/modules/field/tests/src/FunctionalJavascript/EntityReference/EntityReferenceAdminTest.php
PHPUnit 6.5.14 by Sebastian Bergmann and contributors.

Testing Drupal\Tests\field\FunctionalJavascript\EntityReference\EntityReferenceAdminTest
.                                                                   1 / 1 (100%)

Time: 59.31 seconds, Memory: 6.00MB

OK (1 test, 25 assertions)

HTML output was generated
http://appserver/sites/simpletest/browser_output/Drupal_Tests_field_FunctionalJavascript_EntityReference_EntityReferenceAdminTest-5-18668553.html
http://appserver/sites/simpletest/browser_output/Drupal_Tests_field_FunctionalJavascript_EntityReference_EntityReferenceAdminTest-6-18668553.html
http://appserver/sites/simpletest/browser_output/Drupal_Tests_field_FunctionalJavascript_EntityReference_EntityReferenceAdminTest-7-18668553.html
http://appserver/sites/simpletest/browser_output/Drupal_Tests_field_FunctionalJavascript_EntityReference_EntityReferenceAdminTest-8-18668553.html
http://appserver/sites/simpletest/browser_output/Drupal_Tests_field_FunctionalJavascript_EntityReference_EntityReferenceAdminTest-9-18668553.html
http://appserver/sites/simpletest/browser_output/Drupal_Tests_field_FunctionalJavascript_EntityReference_EntityReferenceAdminTest-10-18668553.html
http://appserver/sites/simpletest/browser_output/Drupal_Tests_field_FunctionalJavascript_EntityReference_EntityReferenceAdminTest-11-18668553.html
http://appserver/sites/simpletest/browser_output/Drupal_Tests_field_FunctionalJavascript_EntityReference_EntityReferenceAdminTest-12-18668553.html
http://appserver/sites/simpletest/browser_output/Drupal_Tests_field_FunctionalJavascript_EntityReference_EntityReferenceAdminTest-13-18668553.html
http://appserver/sites/simpletest/browser_output/Drupal_Tests_field_FunctionalJavascript_EntityReference_EntityReferenceAdminTest-14-18668553.html
http://appserver/sites/simpletest/browser_output/Drupal_Tests_field_FunctionalJavascript_EntityReference_EntityReferenceAdminTest-15-18668553.html
http://appserver/sites/simpletest/browser_output/Drupal_Tests_field_FunctionalJavascript_EntityReference_EntityReferenceAdminTest-16-18668553.html
http://appserver/sites/simpletest/browser_output/Drupal_Tests_field_FunctionalJavascript_EntityReference_EntityReferenceAdminTest-17-18668553.html
http://appserver/sites/simpletest/browser_output/Drupal_Tests_field_FunctionalJavascript_EntityReference_EntityReferenceAdminTest-18-18668553.html
http://appserver/sites/simpletest/browser_output/Drupal_Tests_field_FunctionalJavascript_EntityReference_EntityReferenceAdminTest-19-18668553.html
http://appserver/sites/simpletest/browser_output/Drupal_Tests_field_FunctionalJavascript_EntityReference_EntityReferenceAdminTest-20-18668553.html
http://appserver/sites/simpletest/browser_output/Drupal_Tests_field_FunctionalJavascript_EntityReference_EntityReferenceAdminTest-21-18668553.html
http://appserver/sites/simpletest/browser_output/Drupal_Tests_field_FunctionalJavascript_EntityReference_EntityReferenceAdminTest-22-18668553.html
http://appserver/sites/simpletest/browser_output/Drupal_Tests_field_FunctionalJavascript_EntityReference_EntityReferenceAdminTest-23-18668553.html
http://appserver/sites/simpletest/browser_output/Drupal_Tests_field_FunctionalJavascript_EntityReference_EntityReferenceAdminTest-24-18668553.html
http://appserver/sites/simpletest/browser_output/Drupal_Tests_field_FunctionalJavascript_EntityReference_EntityReferenceAdminTest-25-18668553.html
http://appserver/sites/simpletest/browser_output/Drupal_Tests_field_FunctionalJavascript_EntityReference_EntityReferenceAdminTest-26-18668553.html
```

These examples use `lando phpunit`, the command added in PR #2. The blog post has a similar `lando test` command, but in this repository that still has its original implementation, based on `run-tests.sh`.