### PR TITLE
Adds instructions for patching contrib modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,22 @@ lando create-patch
 
 This will output a patch file to `/app/web/ISSUE####-COMMENT#.patch`, which you can upload to the drupal.org issue.
 
+#### Creating a Patch for a Contrib Module
+
+To create a patch for a contrib module, for example [Admin Toolbar](https://www.drupal.org/project/admin_toolbar), go to [Version control](https://www.drupal.org/project/admin_toolbar/git-instructions), follow the instructions how to clone the correct version and `cd` into the module folder.
+
+Inside the contrib module folder, create a branch in the format `ISSUE####-COMMENT#.patch`:
+
+```
+git checkout -b 1234567-admin_toolbar-improved-paths
+```
+When you are ready to create the patch, add any new files and updates to existing files, and create the patch:
+
+```
+git add -A
+git diff 1234567-admin_toolbar-improved-paths > 1234567-admin_toolbar-improved-paths.patch
+```
+
 ## Running Tests
 
 When you create a patch you may have written tests for it that you want to run. At a minimum you'll want to run the tests for the module the patch is for to make sure your changes have not introduced regressions. To run the tests use the `lando test` command. To see what you can do use:

--- a/README.md
+++ b/README.md
@@ -116,13 +116,18 @@ lando create-patch
 
 This will output a patch file to `/app/web/ISSUE####-COMMENT#.patch`, which you can upload to the drupal.org issue.
 
-#### Creating a Patch for a Contrib Module
+#### Contrib Module
 
-To create a patch for a contrib module, for example [Admin Toolbar](https://www.drupal.org/project/admin_toolbar), go to [Version control](https://www.drupal.org/project/admin_toolbar/git-instructions), follow the instructions how to clone the correct version and `cd` into the module folder.
+To create a patch for a contrib module, for example [Admin Toolbar](https://www.drupal.org/project/admin_toolbar), download it to the modules folder, following the instructions under [Version control](https://www.drupal.org/project/admin_toolbar/git-instructions):
 
+```
+cd web/modules
+git clone --branch 8.x-2.x https://git.drupalcode.org/project/admin_toolbar.git
+```
 Inside the contrib module folder, create a branch in the format `ISSUE####-COMMENT#.patch`:
 
 ```
+cd admin_toolbar
 git checkout -b 1234567-admin_toolbar-improved-paths
 ```
 When you are ready to create the patch, add any new files and updates to existing files, and create the patch:


### PR DESCRIPTION
It doesn't seem like `lando create-patch` works for contrib modules ...