### PR TITLE
Allow destroy command to delete web folder

### DIFF
--- a/.lando.yml
+++ b/.lando.yml
@@ -63,6 +63,7 @@ tooling:
 
 events:
   post-destroy:
+    - chmod 777 -R web/sites/default
     - rm -rfv web
   pre-rebuild:
     - rm -rfv web

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Next `rebuild` the `drupal-contributions` app:
 lando rebuild -y
 ```
 
-This will pull in the drupal source code from the `9.1.x-dev` branch, run `composer install` to get dependencies, install Drupal, enable `simpletest` module, and provide us with a one time login link (`uli`).
+This will pull in the drupal source code from the `9.2.x-dev` branch, run `composer install` to get dependencies, install Drupal, enable `simpletest` module, and provide us with a one time login link (`uli`).
 
 After `rebuild` completes you should see something similar to this:
 
@@ -204,7 +204,7 @@ lando phpunit web/core/modules/big_pipe/tests/src/Functional/BigPipeTest.php
 
 ## La Fin
 
-Once you have the `9.1.x` you can keep it and sync it periodically and `lando start`'s will keep that around. If you want to totally start fresh:
+Once you have the `9.2.x` you can keep it and sync it periodically and `lando start`'s will keep that around. If you want to totally start fresh:
 
 ```
 # destroys drupal-contributions app and removes /web


### PR DESCRIPTION
`chmod`'ding the `web` folder recursively with  `777` before running `rm -rfv web`  seems to do the trick.