### PR TITLE
Add support for running Nightwatch tests

### DIFF
--- a/.lando.yml
+++ b/.lando.yml
@@ -5,14 +5,31 @@ config:
 
 services:
   appserver:
+    build_as_root:
+      # Note that you will want to use the script for the major version of node you want to install
+      # See: https://github.com/nodesource/distributions/blob/master/README.md#installation-instructions
+      - curl -sL https://deb.nodesource.com/setup_12.x | bash -
+      - apt-get install -y nodejs
+      - npm install --global yarn
     run:
       # @todo remove invocation of drupal-phpunit-upgrade again once https://www.drupal.org/project/drupal/issues/3099061 is resolved.
       - cd /app/web && composer require drush/drush && composer install && composer run-script drupal-phpunit-upgrade
+      - mkdir -p private/browsertest_output
+      - yarn install --non-interactive --cwd /app/web/core
     overrides:
       environment:
         SIMPLETEST_BASE_URL: "https://drupal-contributions.lndo.site/"
         SIMPLETEST_DB: "sqlite://localhost/tmp/db.sqlite"
         MINK_DRIVER_ARGS_WEBDRIVER: '["chrome", {"browserName":"chrome","chromeOptions":{"args":["--disable-gpu","--headless", "--no-sandbox"]}}, "http://chrome:9515"]'
+        # Nightwatch
+        DRUPAL_TEST_BASE_URL: 'http://appserver'
+        DRUPAL_TEST_DB_URL: 'mysql://drupal9:drupal9@database:3306/drupal9'
+        DRUPAL_TEST_WEBDRIVER_HOSTNAME: chrome
+        DRUPAL_TEST_WEBDRIVER_PORT: 9515
+        DRUPAL_TEST_CHROMEDRIVER_AUTOSTART: 'false'
+        DRUPAL_TEST_WEBDRIVER_CHROME_ARGS: "--disable-gpu --headless --no-sandbox"
+        DRUPAL_NIGHTWATCH_OUTPUT: reports/nightwatch
+        DRUPAL_NIGHTWATCH_IGNORE_DIRECTORIES: node_modules,vendor,.*,sites/*/files,sites/*/private,sites/simpletest
   chrome:
     type: compose
     app_mount: false
@@ -60,6 +77,12 @@ tooling:
       service: appserver
       cmd:
         - php /app/web/core/scripts/run-tests.sh --php /usr/local/bin/php --url https://drupal-contributions.lndo.site --color --verbose
+
+  nightwatch:
+    service: appserver
+    description: Run Nightwatch.js
+    cmd: yarn test:nightwatch
+    dir: /app/web/core
 
 events:
   post-destroy:

--- a/README.md
+++ b/README.md
@@ -2,12 +2,17 @@
 
 This repo is intended to make it easy to contribute to the [Drupal core](https://drupal.org/project/drupal) and contrib projects.
 
-- [Why](#why)
-- [How](#how)
-- [Testing Drupal Patches](#testing-drupal-patches)
-- [Creating a Patch](#creating-a-patch)
-- [Running Tests](#running-tests)
-- [La Fin](#la-fin)
+- [Lando + Drupal Contributions](#lando--drupal-contributions)
+  - [Why?](#why)
+  - [How?](#how)
+  - [Testing Drupal Patches](#testing-drupal-patches)
+  - [Creating a Patch](#creating-a-patch)
+      - [Core Patch Example](#core-patch-example)
+      - [Contrib Module Example](#contrib-module-example)
+  - [Running Tests](#running-tests)
+      - [PHPUnit](#phpunit)
+      - [Nightwatch](#nightwatch)
+  - [La Fin](#la-fin)
 
 ## Why?
 
@@ -200,6 +205,26 @@ Run a single test from the BigPipe module:
 
 ```
 lando phpunit web/core/modules/big_pipe/tests/src/Functional/BigPipeTest.php
+```
+
+#### Nightwatch
+
+To run only core tests, run:
+
+```
+lando nightwatch --tag core
+```
+
+To skip running core tests, run:
+
+```
+lando nightwatch --skiptags core
+```
+
+To run a single test, run e.g:
+
+```
+lando nightwatch tests/Drupal/Nightwatch/Tests/exampleTest.js
 ```
 
 ## La Fin


### PR DESCRIPTION
Real credit goes to @mglaman here - this is ported from the repo he created for a Nightwatch training session at Midcamp.

Adding node/yarn on the appserver feels a little odd, but the site install script that Nightwatch depends on runs php commands behind the secnes.

To run only core tests, run:

```
lando nightwatch --tag core
```

To skip running core tests, run:

```
lando nightwatch --skiptags core
```

To run a single test, run e.g:

```
lando nightwatch tests/Drupal/Nightwatch/Tests/exampleTest.js