### PR TITLE
Remove invocation of drupal-phpunit-upgrade in Drupal 9

### DIFF
--- a/.lando.yml
+++ b/.lando.yml
@@ -6,8 +6,7 @@ config:
 services:
   appserver:
     run:
-      # @todo remove invocation of drupal-phpunit-upgrade again once https://www.drupal.org/project/drupal/issues/3099061 is resolved.
-      - cd /app/web && composer require drush/drush && composer install && composer run-script drupal-phpunit-upgrade
+      - cd /app/web && composer require drush/drush && composer install
     overrides:
       environment:
         SIMPLETEST_BASE_URL: "https://drupal-contributions.lndo.site/"


### PR DESCRIPTION
Drupal 9 is using PHPUnit 8.5.15, and the problem in [Can't run PHPUnit tests since Drupal 8.8.0 on PHP 7.3+](https://www.drupal.org/project/drupal/issues/3204947) was:

> ERROR: PHPUnit testing framework version 7 or greater is required when running on PHP 7.3 or greater. Run the command 'composer run-script drupal-phpunit-upgrade' in order to fix this.

Tests work without running `composer run-script drupal-phpunit-upgrade` in Drupal 9:

```
$ lando phpunit --group big_pipe
PHPUnit 8.5.15 by Sebastian Bergmann and contributors.

Testing 
...............................                                   31 / 31 (100%)
Time: 1.69 minutes, Memory: 881.00 MB
OK (31 tests, 253 assertions)

```