### PR TITLE
Add a core-check command

### DIFF
--- a/.lando.yml
+++ b/.lando.yml
@@ -73,6 +73,11 @@ tooling:
     cmd:
       - appserver: php /app/web/vendor/bin/phpunit -c /app/phpunit.xml
 
+  core-check:
+    service: appserver
+    cmd:
+      - appserver: php /app/scripts/core-check.php
+
   test:
       service: appserver
       cmd:

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Using this repo gives you a `.lando.yml` file configured for Drupal contribution
 - Adds a `lando si` command to reinstall the site with fresh DB if you need one (without rebuilding)
 - Adds a `lando patch URL` command to pull down and apply a patch from drupal.org
 - Adds a `lando revert PATCH_NAME` command should you need/want to revert a patch
+- Adds a `lando core-check` coommand to check code standards and spelling
 - Adds a `lando create-patch` coommand to create a patch from the current branch
 
 ## How?
@@ -106,7 +107,15 @@ We can now leave a comment on the issue saying that we tested the patch and it w
 
 ## Creating a Patch
 
-If you are fixing a drupal.org issue, you should enter the `web` folder, checkout a branch using the prescribed naming conventions `ISSUE####-COMMENT#`. Write your code. Commit your code. Then you can utilize the `lando create-patch` to output the patch file based on your branch name.
+If you are fixing a drupal.org issue, you should enter the `web` folder, checkout a branch using the prescribed naming conventions `ISSUE####-COMMENT#`. Write your code. Commit your code. Check your code using `lando core-check`. Then you can utilize the `lando create-patch` to output the patch file based on your branch name.
+
+```
+lando core-check
+```
+
+This will run the same tests that the testbot runs before running the actual
+PHPUnit tests: spell check, CodeSniffer, etc. You can ignore reports that your
+files have permissions 664 instead of 644.
 
 ```
 lando create-patch
@@ -123,6 +132,7 @@ git checkout -b 987654-new-patch
 echo "TEST" >> core/CHANGELOG.txt
 git add core/CHANGELOG.txt
 git commit -m "Updates CHANGELOG.txt"
+lando core-check
 lando create-patch
 ```
 

--- a/scripts/core-check.php
+++ b/scripts/core-check.php
@@ -1,0 +1,14 @@
+<?php
+
+/**
+ * @file
+ * A wrapper for core/scripts/dev/commit-code-check.sh using the configured
+ * branch.
+ */
+
+include '/app/config/drupal-branch.php';
+
+exec(
+  "cd /app/web &&
+  bash /app/web/core/scripts/dev/commit-code-check.sh --branch $drupalBranch"
+);


### PR DESCRIPTION
Add `lando core-check` as a wrapper for `core/scripts/dev/core-check.sh`, using the configured branch. From that file:

```bash
# The script makes the following checks:
# - Spell checking.
# - File modes.
# - No changes to core/node_modules directory.
# - PHPCS checks PHP and YAML files.
# - Eslint checks JavaScript files.
# - Checks .es6.js and .js files are equivalent.
# - Stylelint checks CSS files.
# - Checks .pcss.css and .css files are equivalent.
```

Example: after applying a patch and committing it on a separate branch,

```bash
lando core-check
CSpell: Files checked: 2, Issues found: 0 in 0 files
```