### PR TITLE
Update the default branch of Drupal core

### DIFF
--- a/config/drupal-branch.php
+++ b/config/drupal-branch.php
@@ -4,4 +4,4 @@
  * @file
  * The branch of Drupal core targeted by the current issue.
  */
-$drupalBranch = '9.2.x';
+$drupalBranch = '9.3.x';


### PR DESCRIPTION
From almost any core issue that used to target 9.2.x:

> Drupal 9.2.0-alpha1 will be released the week of May 3, 2021, which means new developments and disruptive changes should now be targeted for the 9.3.x-dev branch. For more information see the Drupal core minor version schedule and the Allowed changes during the Drupal core release cycle.