### PR TITLE
Remove SimpleTest for D9

### DIFF
--- a/.lando.yml
+++ b/.lando.yml
@@ -77,11 +77,6 @@ tooling:
     cmd:
       - appserver: php /app/scripts/core-check.php
 
-  test:
-      service: appserver
-      cmd:
-        - php /app/web/core/scripts/run-tests.sh --php /usr/local/bin/php --url https://drupal-contributions.lndo.site --color --verbose
-
   nightwatch:
     service: appserver
     description: Run Nightwatch.js

--- a/.lando.yml
+++ b/.lando.yml
@@ -28,7 +28,7 @@ services:
         DRUPAL_TEST_CHROMEDRIVER_AUTOSTART: 'false'
         DRUPAL_TEST_WEBDRIVER_CHROME_ARGS: "--disable-gpu --headless --no-sandbox"
         DRUPAL_NIGHTWATCH_OUTPUT: reports/nightwatch
-        DRUPAL_NIGHTWATCH_IGNORE_DIRECTORIES: node_modules,vendor,.*,sites/*/files,sites/*/private
+        DRUPAL_NIGHTWATCH_IGNORE_DIRECTORIES: node_modules,vendor,.*,sites/*/files,sites/*/private,sites/simpletest
   chrome:
     type: compose
     app_mount: false

--- a/.lando.yml
+++ b/.lando.yml
@@ -17,6 +17,8 @@ services:
       - yarn install --non-interactive --cwd /app/web/core
     overrides:
       environment:
+        SIMPLETEST_BASE_URL: "https://drupal-contributions.lndo.site/"
+        SIMPLETEST_DB: "sqlite://localhost/tmp/db.sqlite"
         MINK_DRIVER_ARGS_WEBDRIVER: '["chrome", {"browserName":"chrome","chromeOptions":{"args":["--disable-gpu","--headless", "--no-sandbox"]}}, "http://chrome:9515"]'
         # Nightwatch
         DRUPAL_TEST_BASE_URL: 'http://appserver'

--- a/.lando.yml
+++ b/.lando.yml
@@ -17,8 +17,6 @@ services:
       - yarn install --non-interactive --cwd /app/web/core
     overrides:
       environment:
-        SIMPLETEST_BASE_URL: "https://drupal-contributions.lndo.site/"
-        SIMPLETEST_DB: "sqlite://localhost/tmp/db.sqlite"
         MINK_DRIVER_ARGS_WEBDRIVER: '["chrome", {"browserName":"chrome","chromeOptions":{"args":["--disable-gpu","--headless", "--no-sandbox"]}}, "http://chrome:9515"]'
         # Nightwatch
         DRUPAL_TEST_BASE_URL: 'http://appserver'
@@ -28,7 +26,7 @@ services:
         DRUPAL_TEST_CHROMEDRIVER_AUTOSTART: 'false'
         DRUPAL_TEST_WEBDRIVER_CHROME_ARGS: "--disable-gpu --headless --no-sandbox"
         DRUPAL_NIGHTWATCH_OUTPUT: reports/nightwatch
-        DRUPAL_NIGHTWATCH_IGNORE_DIRECTORIES: node_modules,vendor,.*,sites/*/files,sites/*/private,sites/simpletest
+        DRUPAL_NIGHTWATCH_IGNORE_DIRECTORIES: node_modules,vendor,.*,sites/*/files,sites/*/private
   chrome:
     type: compose
     app_mount: false

--- a/README.md
+++ b/README.md
@@ -24,8 +24,6 @@ Using this repo gives you a `.lando.yml` file configured for Drupal contribution
 
 - Automatically grabs the Drupal source code and runs `composer install` on `lando rebuild -y`
 - Automatically kills the source code and database on `lando rebuild -y` so you can start fresh with each patch
-- Automatically enables `simpletest`
-- Adds a `lando test` command to invoke Drupal simpletests
 - Adds a `lando phpunit` command to invoke PHPUnit tests
 - Adds a `lando si` command to reinstall the site with fresh DB if you need one (without rebuilding)
 - Adds a `lando patch URL` command to pull down and apply a patch from drupal.org
@@ -54,7 +52,7 @@ Next `rebuild` the `drupal-contributions` app:
 lando rebuild -y
 ```
 
-This will pull in the drupal source code from the `9.2.x-dev` branch, run `composer install` to get dependencies, install Drupal, enable `simpletest` module, and provide us with a one time login link (`uli`).
+This will pull in the drupal source code from the `9.3.x-dev` branch, run `composer install` to get dependencies, install Drupal, and provide us with a one time login link (`uli`).
 
 After `rebuild` completes you should see something similar to this:
 

--- a/scripts/rebuild.sh
+++ b/scripts/rebuild.sh
@@ -1,7 +1,6 @@
 #!/bin/sh
 
 /app/web/vendor/drush/drush/drush --root=/app/web si --db-url=mysql://drupal9:drupal9@database/drupal9 -y
-/app/web/vendor/drush/drush/drush --root=/app/web en simpletest -y
 mkdir -p -m 777 /app/web/sites/simpletest/browser_output
 find /app/web/sites/default -type d -exec chmod 777 '{}' \;
 /app/web/vendor/drush/drush/drush --root=/app/web --uri=https://drupal-contributions.lndo.site uli


### PR DESCRIPTION
I am not sure if the SimpleTest folders and DB config can be removed yet (see [Running PHPUnit tests](https://www.drupal.org/docs/automated-testing/phpunit-in-drupal/running-phpunit-tests)) but here is a start, which removes SimpleTest from the README file and doesn't enable the module, to prevent this error after `lando rebuild -y`:

```
 [error]  Unable to install module 'simpletest' due to unmet requirement(s):
  - SimpleTest has been removed from Drupal 9.0.0 and can no longer be installed. A contributed module is available for those who wish to continue using SimpleTest during the transition from Drupal 8 to 9. <a href="https://www.drupal.org/node/3091784">See the change record for more information</a>. 
```