### PR TITLE
Update Drupal version to 9.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Next `rebuild` the `drupal-contributions` app:
 lando rebuild -y
 ```
 
-This will pull in the drupal source code from the `9.3.x-dev` branch, run `composer install` to get dependencies, install Drupal, and provide us with a one time login link (`uli`).
+This will pull in the drupal source code from the `9.4.x-dev` branch, run `composer install` to get dependencies, install Drupal, and provide us with a one time login link (`uli`).
 
 After `rebuild` completes you should see something similar to this:
 

--- a/config/drupal-branch.php
+++ b/config/drupal-branch.php
@@ -4,4 +4,4 @@
  * @file
  * The branch of Drupal core targeted by the current issue.
  */
-$drupalBranch = '9.3.x';
+$drupalBranch = '9.4.x';


### PR DESCRIPTION
Drupal core 9.4.x-dev was Released Dec 02 2021: https://www.drupal.org/project/drupal.