### PR TITLE
Define PHPUnit output directory and URL in .lando.yml

### DIFF
--- a/.lando.yml
+++ b/.lando.yml
@@ -19,6 +19,8 @@ services:
       environment:
         SIMPLETEST_BASE_URL: "https://drupal-contributions.lndo.site/"
         SIMPLETEST_DB: "sqlite://localhost/tmp/db.sqlite"
+        BROWSERTEST_OUTPUT_DIRECTORY: '/app/web/sites/simpletest/browser_output'
+        BROWSERTEST_OUTPUT_BASE_URL: 'https://drupal-contributions.lndo.site'
         MINK_DRIVER_ARGS_WEBDRIVER: '["chrome", {"browserName":"chrome","chromeOptions":{"args":["--disable-gpu","--headless", "--no-sandbox"]}}, "http://chrome:9515"]'
         # Nightwatch
         DRUPAL_TEST_BASE_URL: 'http://appserver'

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -10,12 +10,12 @@
     <ini name="memory_limit" value="-1"/>
     <env name="SIMPLETEST_BASE_URL" value=""/>
     <env name="SIMPLETEST_DB" value=""/>
-    <env name="BROWSERTEST_OUTPUT_DIRECTORY" value="/app/web/sites/simpletest/browser_output"/>
+    <env name="BROWSERTEST_OUTPUT_DIRECTORY" value=""/>
     <env name="BROWSERTEST_OUTPUT_BASE_URL" value=""/>
-    <env name="MINK_DRIVER_CLASS" value=''/>
-    <env name="MINK_DRIVER_ARGS" value=''/>
-    <env name="MINK_DRIVER_ARGS_PHANTOMJS" value=''/>
-    <env name="MINK_DRIVER_ARGS_WEBDRIVER" value=''/>
+    <env name="MINK_DRIVER_CLASS" value=""/>
+    <env name="MINK_DRIVER_ARGS" value=""/>
+    <env name="MINK_DRIVER_ARGS_PHANTOMJS" value=""/>
+    <env name="MINK_DRIVER_ARGS_WEBDRIVER" value=""/>
   </php>
   <testsuites>
     <testsuite name="unit">

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -10,8 +10,8 @@
     <ini name="memory_limit" value="-1"/>
     <env name="SIMPLETEST_BASE_URL" value=""/>
     <env name="SIMPLETEST_DB" value=""/>
-    <env name="BROWSERTEST_OUTPUT_DIRECTORY" value=""/>
-    <env name="BROWSERTEST_OUTPUT_BASE_URL" value="/app/web/sites/simpletest/browser_output"/>
+    <env name="BROWSERTEST_OUTPUT_DIRECTORY" value="/app/web/sites/simpletest/browser_output"/>
+    <env name="BROWSERTEST_OUTPUT_BASE_URL" value=""/>
     <env name="MINK_DRIVER_CLASS" value=''/>
     <env name="MINK_DRIVER_ARGS" value=''/>
     <env name="MINK_DRIVER_ARGS_PHANTOMJS" value=''/>


### PR DESCRIPTION
Currently, no HTML is generated while running a test. Defining the `BROWSERTEST_OUTPUT_DIRECTORY` and `BROWSERTEST_OUTPUT_BASE_URL` in the environment, PHPUnit will output links to saved HTML assets generated during a test.

### Currently
```
$ lando phpunit web/core/modules/color/tests/src/Functional/ColorConfigSchemaTest.php
PHPUnit 8.5.21 by Sebastian Bergmann and contributors.

Testing Drupal\Tests\color\Functional\ColorConfigSchemaTest
.                                                                   1 / 1 (100%)
Time: 5.11 seconds, Memory: 8.00 MB
OK (1 test, 8 assertions)
```

### After update
```
$ lando phpunit web/core/modules/color/tests/src/Functional/ColorConfigSchemaTest.php
PHPUnit 8.5.21 by Sebastian Bergmann and contributors.

Testing Drupal\Tests\color\Functional\ColorConfigSchemaTest
.                                                                   1 / 1 (100%)

Time: 5.14 seconds, Memory: 8.00 MB

OK (1 test, 8 assertions)

HTML output was generated
https://drupal-contributions.lndo.site/sites/simpletest/browser_output/Drupal_Tests_color_Functional_ColorConfigSchemaTest-1-28022746.html
https://drupal-contributions.lndo.site/sites/simpletest/browser_output/Drupal_Tests_color_Functional_ColorConfigSchemaTest-2-28022746.html
https://drupal-contributions.lndo.site/sites/simpletest/browser_output/Drupal_Tests_color_Functional_ColorConfigSchemaTest-3-28022746.html
https://drupal-contributions.lndo.site/sites/simpletest/browser_output/Drupal_Tests_color_Functional_ColorConfigSchemaTest-4-28022746.html
https://drupal-contributions.lndo.site/sites/simpletest/browser_output/Drupal_Tests_color_Functional_ColorConfigSchemaTest-5-28022746.html
https://drupal-contributions.lndo.site/sites/simpletest/browser_output/Drupal_Tests_color_Functional_ColorConfigSchemaTest-6-28022746.html
```