### PR TITLE
Add .lando.local.yml to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 web
 vendor
 node_modules
+.lando.local.yml
 /*.patch
 *.sql
 *.sql.gz


### PR DESCRIPTION
Adds `.lando.local.yml` to `.gitignore` for setting local overrides of the provided config.