### PR TITLE
Update node version in .lando.yml for the 9.x recipe

### DIFF
--- a/.lando.yml
+++ b/.lando.yml
@@ -8,7 +8,7 @@ services:
     build_as_root:
       # Note that you will want to use the script for the major version of node you want to install
       # See: https://github.com/nodesource/distributions/blob/master/README.md#installation-instructions
-      - curl -sL https://deb.nodesource.com/setup_12.x | bash -
+      - curl -sL https://deb.nodesource.com/setup_16.x | bash -
       - apt-get install -y nodejs
       - npm install --global yarn
     run:


### PR DESCRIPTION
The Drupal 9 recipe currently breaks with node 12.x. Just like in the 10.x branch, this simply updates node to version 16.x.