### PR TITLE
Fix connection refused on javascript functional tests

### DIFF
--- a/.lando.yml
+++ b/.lando.yml
@@ -36,7 +36,7 @@ services:
     app_mount: false
     services:
       image: drupalci/webdriver-chromedriver:production
-      command: chromedriver --log-path=/tmp/chromedriver.log --verbose --whitelisted-ips=
+      command: chromedriver --log-path=/tmp/chromedriver.log --allowed-origins=* --verbose --whitelisted-ips=
 
 tooling:
   drush:


### PR DESCRIPTION
Recently I had to develop a javascript functional test, and there's an error happening on any functional javascript test(at least for me), if you execute the following command:
`$ lando phpunit -v web/core/modules/filter/tests/src/FunctionalJavascript/FilterHtmlTest.php`

You'll get a connection refused error:

```
PHPUnit 8.5.21 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.0.17
Configuration: /app/phpunit.xml

Testing Drupal\Tests\filter\FunctionalJavascript\FilterHtmlTest
S                                                                   1 / 1 (100%)

Time: 6.97 seconds, Memory: 8.00 MB

There was 1 skipped test:

1) Drupal\Tests\filter\FunctionalJavascript\FilterHtmlTest::testTableTags
The test wasn't able to connect to your webdriver instance. For more information read core/tests/README.md.

The original message while starting Mink: Could not open connection: Curl error thrown for http POST to http://chrome:9515/session with params: {"desiredCapabilities":{"browserName":"chrome","name":"Behat Test","chromeOptions":{"args":["--disable-gpu","--headless","--no-sandbox"]}}}

Failed to connect to chrome port 9515: Connection refused

/app/web/core/tests/Drupal/FunctionalJavascriptTests/WebDriverTestBase.php:55
/app/web/core/tests/Drupal/Tests/BrowserTestBase.php:381
/app/web/vendor/phpunit/phpunit/src/Framework/TestResult.php:703

OK, but incomplete, skipped, or risky tests!
Tests: 1, Assertions: 1, Skipped: 1.
```
I was able to fix this by adding `--allowed-origins=*` into the command on chrome container.

**FYI:**
- Docker version: `Docker version 20.10.12, build e91ed57`
- Docker compose version: `docker-compose version 1.29.2, build 5becea4c`
- Session info: `headless chrome=98.0.4758.102`
- Driver info: `chromedriver=98.0.4758.102 (273bf7ac8c909cde36982d27f66f3c70846a3718-refs/branch-heads/4758@{#1151}),platform=Linux 5.4.0-105-generic x86_64`