### PR TITLE
Add a step to rollback drupal composer after installing drush

### DIFF
--- a/.lando.yml
+++ b/.lando.yml
@@ -12,7 +12,7 @@ services:
       - apt-get install -y nodejs
       - npm install --global yarn
     run:
-      - cd /app/web && composer require drush/drush && composer install
+      - cd /app/web && composer require drush/drush && composer install && git checkout composer.json composer.lock composer/Metapackage/CoreRecommended/composer.json composer/Metapackage/PinnedDevDependencies/composer.json
       - mkdir -p private/browsertest_output
       - yarn install --non-interactive --cwd /app/web/core
     overrides:


### PR DESCRIPTION
This is a followup from #37, I've tested the suggestion from @serundeputy, and it looks great, I just had to add some more files, now I'm able to rebuild, use drush and git is no longer tracking the composer files inside web folder.