### PR TITLE
Update to Drupal 9.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Next `rebuild` the `drupal-contributions` app:
 lando rebuild -y
 ```
 
-This will pull in the drupal source code from the `9.4.x-dev` branch, run `composer install` to get dependencies, install Drupal, and provide us with a one time login link (`uli`).
+This will pull in the drupal source code from the `9.5.x-dev` branch, run `composer install` to get dependencies, install Drupal, and provide us with a one time login link (`uli`).
 
 After `rebuild` completes you should see something similar to this:
 
@@ -287,7 +287,7 @@ lando nightwatch tests/Drupal/Nightwatch/Tests/exampleTest.js
 
 ## La Fin
 
-Once you have the `9.2.x` you can keep it and sync it periodically and `lando start`'s will keep that around. If you want to totally start fresh:
+Once you have the `9.5.x` you can keep it and sync it periodically and `lando start`'s will keep that around. If you want to totally start fresh:
 
 ```
 # destroys drupal-contributions app and removes /web

--- a/README.md
+++ b/README.md
@@ -298,4 +298,4 @@ lando destroy -y
 lando rebuild  -y
 ```
 
-*Original text from [Lando + Drupal Contributions](https://blog.lando.dev/2020/06/30/lando-drupal-contributions/) by [Geoff St. Pierre](https://twitter.com/serundeputy).*
+*Original text from [Lando + Drupal Contributions](https://lando.dev/blog/2020/06/02/lando-drupal-contributions/) by [Geoff St. Pierre](https://twitter.com/serundeputy).*

--- a/config/drupal-branch.php
+++ b/config/drupal-branch.php
@@ -4,4 +4,4 @@
  * @file
  * The branch of Drupal core targeted by the current issue.
  */
-$drupalBranch = '9.4.x';
+$drupalBranch = '9.5.x';


### PR DESCRIPTION
[9.5.x-dev](https://www.drupal.org/project/drupal/releases/9.5.x-dev) was released 29 April 2022, let's get Lando synchronized.