### PR TITLE
lando/drupal-contributions#67: Fix rebuild.sh failure on first run

### DIFF
--- a/.lando.yml
+++ b/.lando.yml
@@ -86,11 +86,13 @@ tooling:
     dir: /app/web/core
 
 events:
+  post-start:
+    - if [ ! -d web ] ; then php /app/scripts/get-drupal.php ; fi
   post-destroy:
     - chmod 777 -R web/sites/default
-    - rm -rfv web
+    - echo "Removing web/" && rm -rf /app/web
   pre-rebuild:
-    - rm -rfv web
+    - echo "Removing web/" && rm -rf web
     - appserver: php /app/scripts/get-drupal.php
   post-rebuild:
     - appserver: /app/scripts/rebuild.sh


### PR DESCRIPTION
First run following docs to use `lando rebuild -y` instead of `lando start` did not work, per details in #67.

This should ensure that we _also_ install Drupal even if the Lando environment has not been run before.

Also reduces noise from `rm -rfv` on thousands of files.