### PR TITLE
Fix PHPUnit invalid cookie domain and failing Nightwatch test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ node_modules
 *.sql
 *.sql.gz
 *.gz
++/.phpunit.result.cache

--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,3 @@ node_modules
 *.sql
 *.sql.gz
 *.gz
-+/.phpunit.result.cache

--- a/.lando.yml
+++ b/.lando.yml
@@ -17,12 +17,11 @@ services:
       - yarn install --non-interactive --cwd /app/web/core
     overrides:
       environment:
-        SIMPLETEST_BASE_URL: "https://drupal-contributions.lndo.site/"
+        SIMPLETEST_BASE_URL: "http://drupal-contributions.lndo.site/"
         SIMPLETEST_DB: "sqlite://localhost/tmp/db.sqlite"
         BROWSERTEST_OUTPUT_DIRECTORY: '/app/web/sites/simpletest/browser_output'
-        BROWSERTEST_OUTPUT_BASE_URL: 'https://drupal-contributions.lndo.site'
-        MINK_DRIVER_ARGS_WEBDRIVER: '["chrome", {"browserName":"chrome","chromeOptions":{"args":["--disable-gpu","--headless"]}}, "http://chromedriver:9515"]'
-        # Nightwatch
+        BROWSERTEST_OUTPUT_BASE_URL: 'http://drupal-contributions.lndo.site'
+        MINK_DRIVER_ARGS_WEBDRIVER: '["chrome", {"browserName":"chrome","chromeOptions":{"args":["--disable-gpu","--headless"]}}, "http://chrome:9515"]'        # Nightwatch
         DRUPAL_TEST_BASE_URL: 'http://appserver'
         DRUPAL_TEST_DB_URL: 'mysql://drupal10:drupal10@database:3306/drupal10'
         DRUPAL_TEST_WEBDRIVER_HOSTNAME: chrome
@@ -34,14 +33,17 @@ services:
   chrome:
     type: compose
     scanner: false
+    app_mount: false
     services:
       image: drupalci/chromedriver:production
       expose:
         - "9515"
         - "4444"
+      volumes:
+        - /dev/shm:/dev/shm
       security_opt:
         - seccomp:unconfined
-      command: ["chromedriver",  "--log-path=/tmp/chromedriver.log", "--verbose", "--allowed-ips=", "--allowed-origins=*"]
+      command: ["chromedriver",  "--log-path=/tmp/chromedriver.log", "--verbose", "--allowed-ips=", "--allowed-origins=*", "--whitelisted-ips="]
 
 tooling:
   drush:

--- a/.lando.yml
+++ b/.lando.yml
@@ -21,9 +21,9 @@ services:
         SIMPLETEST_DB: "sqlite://localhost/tmp/db.sqlite"
         BROWSERTEST_OUTPUT_DIRECTORY: '/app/web/sites/simpletest/browser_output'
         BROWSERTEST_OUTPUT_BASE_URL: 'https://drupal-contributions.lndo.site'
-        MINK_DRIVER_ARGS_WEBDRIVER: '["chrome", {"browserName":"chrome","chromeOptions":{"args":["--disable-gpu","--headless", "--no-sandbox"]}}, "http://chrome:9515"]'
+        MINK_DRIVER_ARGS_WEBDRIVER: '["chrome", {"browserName":"chrome","chromeOptions":{"args":["--disable-gpu","--headless"]}}, "http://chromedriver:9515"]'
         # Nightwatch
-        DRUPAL_TEST_BASE_URL: 'http://appserver'
+        DRUPAL_TEST_BASE_URL: 'https://drupal-contributions.lndo.site/'
         DRUPAL_TEST_DB_URL: 'mysql://drupal10:drupal10@database:3306/drupal10'
         DRUPAL_TEST_WEBDRIVER_HOSTNAME: chrome
         DRUPAL_TEST_WEBDRIVER_PORT: 9515
@@ -33,10 +33,15 @@ services:
         DRUPAL_NIGHTWATCH_IGNORE_DIRECTORIES: node_modules,vendor,.*,sites/*/files,sites/*/private,sites/simpletest
   chrome:
     type: compose
-    app_mount: false
+    scanner: false
     services:
-      image: drupalci/webdriver-chromedriver:production
-      command: chromedriver --log-path=/tmp/chromedriver.log --allowed-origins=* --verbose --whitelisted-ips=
+      image: drupalci/chromedriver:production
+      expose:
+        - "9515"
+        - "4444"
+      security_opt:
+        - seccomp:unconfined
+      command: ["chromedriver",  "--log-path=/tmp/chromedriver.log", "--verbose", "--allowed-ips=", "--allowed-origins=*"]
 
 tooling:
   drush:

--- a/.lando.yml
+++ b/.lando.yml
@@ -5,6 +5,7 @@ config:
 
 services:
   appserver:
+    composer_version: 2-latest
     build_as_root:
       # Note that you will want to use the script for the major version of node you want to install
       # See: https://github.com/nodesource/distributions/blob/master/README.md#installation-instructions
@@ -22,7 +23,7 @@ services:
         BROWSERTEST_OUTPUT_DIRECTORY: '/app/web/sites/simpletest/browser_output'
         BROWSERTEST_OUTPUT_BASE_URL: 'http://drupal-contributions.lndo.site'
         MINK_DRIVER_ARGS_WEBDRIVER: '["chrome", {"browserName":"chrome","chromeOptions":{"args":["--disable-gpu","--headless"]}}, "http://chrome:9515"]'        # Nightwatch
-        DRUPAL_TEST_BASE_URL: 'http://appserver'
+        DRUPAL_TEST_BASE_URL: 'http://drupal-contributions.lndo.site'
         DRUPAL_TEST_DB_URL: 'mysql://drupal10:drupal10@database:3306/drupal10'
         DRUPAL_TEST_WEBDRIVER_HOSTNAME: chrome
         DRUPAL_TEST_WEBDRIVER_PORT: 9515

--- a/.lando.yml
+++ b/.lando.yml
@@ -23,7 +23,7 @@ services:
         BROWSERTEST_OUTPUT_BASE_URL: 'https://drupal-contributions.lndo.site'
         MINK_DRIVER_ARGS_WEBDRIVER: '["chrome", {"browserName":"chrome","chromeOptions":{"args":["--disable-gpu","--headless"]}}, "http://chromedriver:9515"]'
         # Nightwatch
-        DRUPAL_TEST_BASE_URL: 'https://drupal-contributions.lndo.site/'
+        DRUPAL_TEST_BASE_URL: 'http://appserver'
         DRUPAL_TEST_DB_URL: 'mysql://drupal10:drupal10@database:3306/drupal10'
         DRUPAL_TEST_WEBDRIVER_HOSTNAME: chrome
         DRUPAL_TEST_WEBDRIVER_PORT: 9515


### PR DESCRIPTION
Fixes: #70. Issue with failing test and `WebDriver\Exception\InvalidCookieDomain: invalid cookie domain message` error message. This update looks like it makes both PHPUnit and Nightwatch work.

New configuration kindly shared by @neclimdul in https://github.com/lando/lando/issues/3411#issuecomment-1143935766.

- [ ] To Do: Test with D9 branch, and if it works apply there as well. Does it need a separate MR?

## After the update

### PHPUnit Olivero test
```
$ lando phpunit --group olivero
PHPUnit 9.5.26 by Sebastian Bergmann and contributors.

Warning:       Your XML configuration validates against a deprecated schema.
Suggestion:    Migrate your XML configuration using "--migrate-configuration"!

Testing 
.........SS                                                       11 / 11 (100%)

Time: 04:28.872, Memory: 337.00 MB

OK, but incomplete, skipped, or risky tests!
Tests: 11, Assertions: 45, Skipped: 2.

HTML output was generated
https://drupal-contributions.lndo.site/sites/simpletest/browser_output/Drupal_FunctionalTests_Theme_OliveroTest-1-85693154.html
https://drupal-contributions.lndo.site/sites/simpletest/browser_output/Drupal_FunctionalTests_Theme_OliveroTest-2-82886258.html
[...]
```

### PHPUnit Password Hashing test
```
$ lando phpunit web/core/tests/Drupal/Tests/Core/Password/PasswordHashingTest.php
PHPUnit 9.5.26 by Sebastian Bergmann and contributors.

Warning:       Your XML configuration validates against a deprecated schema.
Suggestion:    Migrate your XML configuration using "--migrate-configuration"!

Testing Drupal\Tests\Core\Password\PasswordHashingTest
.........                                                           9 / 9 (100%)

Time: 00:00.024, Memory: 10.00 MB

OK (9 tests, 19 assertions)
```

### Nightwatch example test 
```
$ cd web/core/
$ lando nightwatch tests/Drupal/Nightwatch/Tests/exampleTest.js
yarn run v1.22.19
$ node -r dotenv-safe/config ./node_modules/.bin/nightwatch --config ./tests/Drupal/Nightwatch/nightwatch.conf.js tests/Drupal/Nightwatch/Tests/exampleTest.js

[Tests/Example Test] Test Suite
──────────────────────────────────────────────────────────────
ℹ Connected to chrome on port 9515 (138ms).
  Using: chrome (106.0.5249.103) on LINUX.

  ℹ Loaded url http://appserver in 82ms

  Running Test page:
───────────────────────────────────────────────────────────────────────────────────────────────────
  ℹ Loaded url http://appserver/test-page in 196ms
  ✔ Element <body> was visible after 34 milliseconds.
  ✔ Testing if element <body> contains text 'Test page text' (25ms)

  ✨ PASSED. 2 assertions. (310ms)

  Running Page objects test page:
───────────────────────────────────────────────────────────────────────────────────────────────────
  ℹ Loaded url http://appserver/test-page in 46ms
  ✔ Element <body> was visible after 29 milliseconds.
  ✔ Testing if element <Element [name=@body]> contains text 'Test page text' (25ms)
  ✔ Ensuring no deprecation errors have been triggered (6ms)

  ✨ PASSED. 3 assertions. (167ms)

  ✨ PASSED. 5 total assertions (3.142s)
 Wrote HTML report file to: /app/web/core/reports/nightwatch/nightwatch-html-report/index.html

Done in 10.14s.
```

### Nightwatch Olivero test 
```
$ cd web/core/
$ lando nightwatch --tag olivero

  ℹ Loaded url http://drupal-contributions.lndo.site/user/reset/1/1682500376/WmeOV8GaBUGJa70coru0vEtQD9oyeZ60Lapajlh8A4c/login
 in 761ms

  [...]

  ✔ Testing if element <#block-olivero-main-menu> is visible (30ms)
  ✔ Testing if attribute 'aria-checked' of element <button.sticky-header-toggle> equals 'true' (21ms)

  ✨ PASSED. 9 assertions. (2.465s)

  ✨ PASSED. 180 total assertions (3m 10s)
 Wrote HTML report file to: /app/web/core/reports/nightwatch/nightwatch-html-report/index.html

Done in 199.20s.
```