### PR TITLE
Use latest official release of Composer 2

### DIFF
--- a/.lando.yml
+++ b/.lando.yml
@@ -5,7 +5,7 @@ config:
 
 services:
   appserver:
-    composer_version: 2-latest  
+    composer_version: 2-latest
     build_as_root:
       # Note that you will want to use the script for the major version of node you want to install
       # See: https://github.com/nodesource/distributions/blob/master/README.md#installation-instructions

--- a/.lando.yml
+++ b/.lando.yml
@@ -5,6 +5,7 @@ config:
 
 services:
   appserver:
+    composer_version: 2-latest  
     build_as_root:
       # Note that you will want to use the script for the major version of node you want to install
       # See: https://github.com/nodesource/distributions/blob/master/README.md#installation-instructions


### PR DESCRIPTION
Fixes: #69.

If necessary, you can always downgrade by changing that line in `.lando.yml` from: 
`composer_version: 2-latest`

...to:
`composer_version: '2.4.4'`