### PR TITLE
Upgrade Node.js from 16 to 18 to meet Drupal 10.1.x requirements

### DIFF
--- a/.lando.yml
+++ b/.lando.yml
@@ -9,7 +9,7 @@ services:
     build_as_root:
       # Note that you will want to use the script for the major version of node you want to install
       # See: https://github.com/nodesource/distributions/blob/master/README.md#installation-instructions
-      - curl -sL https://deb.nodesource.com/setup_16.x | bash -
+      - curl -fsSL https://deb.nodesource.com/setup_18.x | bash -
       - apt-get install -y nodejs
       - npm install --global yarn
     run:


### PR DESCRIPTION
Node.js 16 has been deprecated and Drupal Core JavaScript development now requires Node.js 18
https://www.drupal.org/node/3358623

Closes #83 