### PR TITLE
Support Drupal 11

### DIFF
--- a/.lando.yml
+++ b/.lando.yml
@@ -9,7 +9,7 @@ services:
     build_as_root:
       # Note that you will want to use the script for the major version of node you want to install
       # See: https://github.com/nodesource/distributions/blob/master/README.md#installation-instructions
-      - curl -sL https://deb.nodesource.com/setup_16.x | bash -
+      - curl -fsSL https://deb.nodesource.com/setup_18.x | bash -
       - apt-get install -y nodejs
       - npm install --global yarn
     run:

--- a/.lando.yml
+++ b/.lando.yml
@@ -1,5 +1,5 @@
 name: drupal-contributions
-recipe: drupal10
+recipe: drupal11
 config:
   webroot: web
 
@@ -9,22 +9,24 @@ services:
     build_as_root:
       # Note that you will want to use the script for the major version of node you want to install
       # See: https://github.com/nodesource/distributions/blob/master/README.md#installation-instructions
-      - curl -fsSL https://deb.nodesource.com/setup_18.x | bash -
+      - curl -fsSL https://deb.nodesource.com/setup_20.x | bash -
       - apt-get install -y nodejs
-      - npm install --global yarn
+      - corepack enable
     run:
       - cd /app/web && composer require drush/drush && composer install
       - mkdir -p private/browsertest_output
-      - yarn install --non-interactive --cwd /app/web/core
+      - yarn --cwd /app/web/core install
     overrides:
       environment:
+        COREPACK_ENABLE_DOWNLOAD_PROMPT: 0
         SIMPLETEST_BASE_URL: "http://drupal-contributions.lndo.site/"
-        SIMPLETEST_DB: "sqlite://localhost/tmp/db.sqlite"
+        #SIMPLETEST_DB: "sqlite://localhost/tmp/db.sqlite"
+        SIMPLETEST_DB: 'mysql://drupal11:drupal11@database:3306/drupal11'
         BROWSERTEST_OUTPUT_DIRECTORY: '/app/web/sites/simpletest/browser_output'
         BROWSERTEST_OUTPUT_BASE_URL: 'http://drupal-contributions.lndo.site'
         MINK_DRIVER_ARGS_WEBDRIVER: '["chrome", {"browserName":"chrome","chromeOptions":{"args":["--disable-gpu","--headless"]}}, "http://chrome:9515"]'        # Nightwatch
         DRUPAL_TEST_BASE_URL: 'http://drupal-contributions.lndo.site'
-        DRUPAL_TEST_DB_URL: 'mysql://drupal10:drupal10@database:3306/drupal10'
+        DRUPAL_TEST_DB_URL: 'mysql://drupal11:drupal11@database:3306/drupal11'
         DRUPAL_TEST_WEBDRIVER_HOSTNAME: chrome
         DRUPAL_TEST_WEBDRIVER_PORT: 9515
         DRUPAL_TEST_CHROMEDRIVER_AUTOSTART: 'false'

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Video presentation: [SFDUG - June 25 - Lando for Contrib / LLC, Corporation or S
 Let's step through how to spin up your contribution workflow. First clone down this repo:
 
 ```
-git clone -b 10.x git@github.com:lando/drupal-contributions.git
+git clone -b 11.x git@github.com:lando/drupal-contributions.git
 cd drupal-contributions
 ```
 
@@ -54,7 +54,7 @@ Next `rebuild` the `drupal-contributions` app:
 lando rebuild -y
 ```
 
-This will pull in the drupal source code from the latest `10.x-dev` branch, run `composer install` to get dependencies, install Drupal, and provide us with a one time login link (`uli`). You can update the version in the `/config/drupal-branch.php` file.
+This will pull in the drupal source code from the latest `11.x-dev` branch, run `composer install` to get dependencies, install Drupal, and provide us with a one time login link (`uli`). You can update the version in the `/config/drupal-branch.php` file.
 
 After `rebuild` completes you should see something similar to this:
 
@@ -83,7 +83,7 @@ and the `web` directory should be populated with the Drupal source code.
 
 #### Test a Core Patch
 
-Now we are ready to find a Drupal core issue. Search the issue queue for a core `10.x` issue that you want to test. Grab the URL of the latest patch and apply it to our `drupal-contributions` environment.
+Now we are ready to find a Drupal core issue. Search the issue queue for a core `11.x` issue that you want to test. Grab the URL of the latest patch and apply it to our `drupal-contributions` environment.
 
 For example, if you choose the issue [Create new "Views Responsive Grid" format for Views Core](https://www.drupal.org/project/drupal/issues/3151553), the latest corresponding patch (as of 23 April 2022) is https://git.drupalcode.org/project/drupal/-/merge_requests/1585.diff ("plain diff" link). To apply this patch:
 
@@ -287,7 +287,7 @@ lando nightwatch tests/Drupal/Nightwatch/Tests/exampleTest.js
 
 ## La Fin
 
-Once you have the latest `10.x-dev` branch you can keep it and sync it periodically and `lando start`'s will keep that around. If you want to totally start fresh:
+Once you have the latest `11.x-dev` branch you can keep it and sync it periodically and `lando start`'s will keep that around. If you want to totally start fresh:
 
 ```
 # destroys drupal-contributions app and removes /web

--- a/config/drupal-branch.php
+++ b/config/drupal-branch.php
@@ -4,4 +4,4 @@
  * @file
  * The branch of Drupal core targeted by the current issue.
  */
-$drupalBranch = '10.1.x';
+$drupalBranch = '11.x';

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,6 +1,93 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="/app/web/core/tests/bootstrap.php" colors="true" beStrictAboutTestsThatDoNotTestAnything="true" beStrictAboutOutputDuringTests="true" beStrictAboutChangesToGlobalState="true" printerClass="\Drupal\Tests\Listeners\HtmlOutputPrinter" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
-  <coverage>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         bootstrap="/app/web/core/tests/bootstrap.php"
+         colors="true"
+         beStrictAboutTestsThatDoNotTestAnything="true"
+         beStrictAboutOutputDuringTests="true"
+         beStrictAboutChangesToGlobalState="true"
+         failOnRisky="true"
+         failOnWarning="true"
+         displayDetailsOnTestsThatTriggerErrors="true"
+         displayDetailsOnTestsThatTriggerWarnings="true"
+         displayDetailsOnTestsThatTriggerDeprecations="true"
+         cacheResult="false"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
+         cacheDirectory=".phpunit.cache">
+  <php>
+    <ini name="error_reporting" value="32767"/>
+    <ini name="memory_limit" value="-1"/>
+    <env name="SIMPLETEST_BASE_URL" value=""/>
+    <env name="SIMPLETEST_DB" value=""/>
+    <env name="BROWSERTEST_OUTPUT_BASE_URL" value=""/>
+    <env name="MINK_DRIVER_CLASS" value=""/>
+    <env name="MINK_DRIVER_ARGS" value=""/>
+    <env name="MINK_DRIVER_ARGS_WEBDRIVER" value=""/>
+  </php>
+  <extensions>
+    <!-- Functional tests HTML output logging. -->
+    <bootstrap class="Drupal\TestTools\Extension\HtmlLogging\HtmlOutputLogger">
+      <!-- The directory where the browser output will be stored. If a relative
+        path is specified, it will be relative to the current working directory
+        of the process running the PHPUnit CLI. In CI environments, this can be
+        overridden by the value set for the "BROWSERTEST_OUTPUT_DIRECTORY"
+        environment variable.
+      -->
+      <parameter name="outputDirectory" value="sites/simpletest/browser_output"/>
+      <!-- By default browser tests print the individual links in the test run
+        report. To avoid overcrowding the output in CI environments, you can
+        set the "verbose" parameter or the "BROWSERTEST_OUTPUT_VERBOSE"
+        environment variable to "false". In GitLabCI, the output is saved
+        anyway as an artifact that can be browsed or downloaded from Gitlab.
+      -->
+      <parameter name="verbose" value="true"/>
+    </bootstrap>
+  </extensions>
+  <testsuites>
+    <testsuite name="unit">
+      <directory>./web/core/tests/Drupal/Tests</directory>
+      <directory>./web/core/modules/**/tests/src/Unit</directory>
+      <directory>./web/core/profiles/**/tests/src/Unit</directory>
+      <directory>./web/core/themes/**/tests/src/Unit</directory>
+      <directory>./web/modules/**/tests/src/Unit</directory>
+      <directory>./web/profiles/**/tests/src/Unit</directory>
+      <directory>./web/themes/**/tests/src/Unit</directory>
+    </testsuite>
+    <testsuite name="kernel">
+      <directory>./web/core/tests/Drupal/KernelTests</directory>
+      <directory>./web/core/modules/**/tests/src/Kernel</directory>
+      <directory>./web/core/recipes/*/tests/src/Kernel</directory>
+      <directory>./web/core/profiles/**/tests/src/Kernel</directory>
+      <directory>./web/core/themes/**/tests/src/Kernel</directory>
+      <directory>./web/modules/**/tests/src/Kernel</directory>
+      <directory>./web/profiles/**/tests/src/Kernel</directory>
+      <directory>./web/themes/**/tests/src/Kernel</directory>
+    </testsuite>
+    <testsuite name="functional">
+      <directory>./web/core/tests/Drupal/FunctionalTests</directory>
+      <directory>./web/core/modules/**/tests/src/Functional</directory>
+      <directory>./web/core/profiles/**/tests/src/Functional</directory>
+      <directory>./web/core/recipes/*/tests/src/Functional</directory>
+      <directory>./web/core/themes/**/tests/src/Functional</directory>
+      <directory>./web/modules/**/tests/src/Functional</directory>
+      <directory>./web/profiles/**/tests/src/Functional</directory>
+      <directory>./web/themes/**/tests/src/Functional</directory>
+    </testsuite>
+    <testsuite name="functional-javascript">
+      <directory>./web/core/tests/Drupal/FunctionalJavascriptTests</directory>
+      <directory>./web/core/modules/**/tests/src/FunctionalJavascript</directory>
+      <directory>./web/core/recipes/*/tests/src/FunctionalJavascript</directory>
+      <directory>./web/core/profiles/**/tests/src/FunctionalJavascript</directory>
+      <directory>./web/core/themes/**/tests/src/FunctionalJavascript</directory>
+      <directory>./web/modules/**/tests/src/FunctionalJavascript</directory>
+      <directory>./web/profiles/**/tests/src/FunctionalJavascript</directory>
+      <directory>./web/themes/**/tests/src/FunctionalJavascript</directory>
+    </testsuite>
+    <testsuite name="build">
+      <directory>./web/core/tests/Drupal/BuildTests</directory>
+    </testsuite>
+  </testsuites>
+  <!-- Settings for coverage reports. -->
+  <source ignoreSuppressionOfDeprecations="true">
     <include>
       <directory>./web/core/includes</directory>
       <directory>./web/core/lib</directory>
@@ -15,43 +102,9 @@
       <directory>./web/modules/*/tests</directory>
       <directory>./web/modules/*/*/src/Tests</directory>
       <directory>./web/modules/*/*/tests</directory>
+      <directory suffix=".api.php">./web/core/lib/**</directory>
+      <directory suffix=".api.php">./web/core/modules/**</directory>
+      <directory suffix=".api.php">./web/modules/**</directory>
     </exclude>
-  </coverage>
-  <php>
-    <ini name="error_reporting" value="32767"/>
-    <ini name="memory_limit" value="-1"/>
-    <env name="SIMPLETEST_BASE_URL" value=""/>
-    <env name="SIMPLETEST_DB" value=""/>
-    <env name="BROWSERTEST_OUTPUT_DIRECTORY" value=""/>
-    <env name="BROWSERTEST_OUTPUT_BASE_URL" value=""/>
-    <env name="MINK_DRIVER_CLASS" value=""/>
-    <env name="MINK_DRIVER_ARGS" value=""/>
-    <env name="MINK_DRIVER_ARGS_PHANTOMJS" value=""/>
-    <env name="MINK_DRIVER_ARGS_WEBDRIVER" value=""/>
-  </php>
-  <testsuites>
-    <testsuite name="unit">
-      <file>./web/core/tests/TestSuites/UnitTestSuite.php</file>
-    </testsuite>
-    <testsuite name="kernel">
-      <file>./web/core/tests/TestSuites/KernelTestSuite.php</file>
-    </testsuite>
-    <testsuite name="functional">
-      <file>./web/core/tests/TestSuites/FunctionalTestSuite.php</file>
-    </testsuite>
-    <testsuite name="functional-javascript">
-      <file>./web/core/tests/TestSuites/FunctionalJavascriptTestSuite.php</file>
-    </testsuite>
-    <testsuite name="build">
-      <file>./web/core//tests/TestSuites/BuildTestSuite.php</file>
-    </testsuite>
-  </testsuites>
-  <listeners>
-    <listener class="\Drupal\Tests\Listeners\DrupalListener">
-    </listener>
-    <!-- The Symfony deprecation listener has to come after the Drupal listener -->
-    <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener">
-    </listener>
-  </listeners>
-  <!-- Filter for coverage reports. -->
+  </source>
 </phpunit>

--- a/scripts/rebuild.sh
+++ b/scripts/rebuild.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-/app/web/vendor/drush/drush/drush --root=/app/web si --db-url=mysql://drupal10:drupal10@database/drupal10 -y
+/app/web/vendor/drush/drush/drush --root=/app/web si --db-url=mysql://drupal11:drupal11@database/drupal11 -y
 mkdir -p -m 777 /app/web/sites/simpletest/browser_output
 find /app/web/sites/default -type d -exec chmod 777 '{}' \;
 /app/web/vendor/drush/drush/drush --root=/app/web --uri=https://drupal-contributions.lndo.site uli

--- a/scripts/site-install.sh
+++ b/scripts/site-install.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 
-/app/web/vendor/drush/drush/drush --root=/app/web si --db-url=mysql://drupal10:drupal10@database/drupal10 -y $1
+/app/web/vendor/drush/drush/drush --root=/app/web si --db-url=mysql://drupal11:drupal11@database/drupal11 -y $1
 find /app/web/sites/default -type d -exec chmod 777 '{}' \;
 /app/web/vendor/drush/drush/drush --root=/app/web --uri=https://drupal-contributions.lndo.site uli


### PR DESCRIPTION
*Do not merge this in the 10.x branch. This should be merged in 11.x which has not been created yet.*

Initial support for Drupal 11.

The MR switches the test database from SQLite to MySQL because Lando ships an outdated version of SQLite (ref. https://github.com/lando/drupal/issues/119)